### PR TITLE
Fix errors for unused data  connection to backend API in Google Cloud 0003

### DIFF
--- a/src/components/customer/CreateView.vue
+++ b/src/components/customer/CreateView.vue
@@ -63,7 +63,7 @@ export default {
       this.__submitToServer(customerData);
     },
     __submitToServer(data) {
-      axios.post(`${server.baseURL}/customer/create`, data).then(data => {
+      axios.post(`${server.baseURL}/customer/create`, data ).then( () => {
         router.push({ name: "home" });
       });
     }

--- a/src/components/customer/EditView.vue
+++ b/src/components/customer/EditView.vue
@@ -70,7 +70,7 @@ export default {
           `${server.baseURL}/customer/update?customerID=${this.id}`,
           customerData
         )
-        .then(data => {
+        .then( () => {
           router.push({ name: "home" });
         });
     },

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,7 +1,7 @@
 // defining baseURL constant to be declared in multiple components
 
 export const server = {
-  baseURL: 'https://customer-list-app-backend-template-1-iftelzoeoa-uc.a.run.app/customer'
+  baseURL: 'https://customer-list-app-backend-template-1-iftelzoeoa-uc.a.run.app'
 }
 
   // DEV baseURL:   baseURL: 'http://localhost:3000'


### PR DESCRIPTION

 - Fixes #3 

I made changes to the component names in the EditView.vue and CreateView.vue file names and changed the file paths in main.ts.

To fix the connection error to the backend API in the GoogleCloud I put the enableCORS function back into the code. I also changed the PORT back to 3000 in the backend app.
See this backend issue:

To correct the next error which was generated, I corrected the incorrect baseURL in the frontend app. I dropped the '/customer' from the baseURL.

I redeployed backend app in the Google Cloud. I re-built the local dev build and deployed it. I tested and the apps worked successfully.

After the code is merged with this pull request I will redeploy frontend to Netlify and test.
